### PR TITLE
Fix compilation issue with x11grab (D->DEC).

### DIFF
--- a/libavdevice/x11grab.c
+++ b/libavdevice/x11grab.c
@@ -614,8 +614,8 @@ static int x11grab_read_close(AVFormatContext *s1)
 #define OFFSET(x) offsetof(X11GrabContext, x)
 #define DEC AV_OPT_FLAG_DECODING_PARAM
 static const AVOption options[] = {
-    { "grab_x", "Initial x coordinate.", OFFSET(x_off), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, D },
-    { "grab_y", "Initial y coordinate.", OFFSET(y_off), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, D },
+    { "grab_x", "Initial x coordinate.", OFFSET(x_off), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, DEC },
+    { "grab_y", "Initial y coordinate.", OFFSET(y_off), AV_OPT_TYPE_INT, { .i64 = 0 }, 0, INT_MAX, DEC },
     { "video_size", "A string describing frame size, such as 640x480 or hd720.", OFFSET(video_size), AV_OPT_TYPE_STRING, {.str = "vga"}, 0, 0, DEC },
     { "framerate", "", OFFSET(framerate), AV_OPT_TYPE_STRING, {.str = "ntsc"}, 0, 0, DEC },
     { "draw_mouse", "Draw the mouse pointer.", OFFSET(draw_mouse), AV_OPT_TYPE_INT, { .i64 = 1 }, 0, 1, DEC },


### PR DESCRIPTION
For me, x11grab did not compile because of a change from b31328d008985f87f0a7c83c700847cef1a4f08c in libavdevice/x11grab.c.
D is reported undeclared.
I'm just guessing that the type information for grab_x and grab_y should be DEC instead of D.
At least it compiles.
I haven't tried using this option it yet, however, I think someone knowing more about AVOption than me can easily see in the source whether my change is correct or wrong faster than I can try this, that's why I didn't try.