### PR TITLE
video: add support for cameras on OSX (AVFoundation framework)

### DIFF
--- a/configure
+++ b/configure
@@ -1404,7 +1404,6 @@ HAVE_LIST_PUB="
 
 HEADERS_LIST="
     AVFoundation_AVFoundation_h
-    CoreVideo_CoreVideo_h
     alsa_asoundlib_h
     altivec_h
     arpa_inet_h
@@ -1978,7 +1977,7 @@ zmbv_encoder_deps="zlib"
 dxva2_deps="dxva2api_h"
 vaapi_deps="va_va_h"
 vda_deps="VideoDecodeAcceleration_VDADecoder_h pthreads"
-vda_extralibs="-framework CoreFoundation -framework CoreMedia -framework CoreVideo -framework VideoDecodeAcceleration -framework QuartzCore"
+vda_extralibs="-framework CoreFoundation -framework VideoDecodeAcceleration -framework QuartzCore"
 vdpau_deps="vdpau_vdpau_h vdpau_vdpau_x11_h"
 
 h263_vaapi_hwaccel_deps="vaapi"
@@ -2138,7 +2137,7 @@ xwma_demuxer_select="riffdec"
 # indevs / outdevs
 alsa_indev_deps="alsa_asoundlib_h snd_pcm_htimestamp"
 alsa_outdev_deps="alsa_asoundlib_h"
-avfoundation_indev_deps="AVFoundation_AVFoundation_h CoreVideo_CoreVideo_h"
+avfoundation_indev_deps="AVFoundation_AVFoundation_h"
 bktr_indev_deps_any="dev_bktr_ioctl_bt848_h machine_ioctl_bt848_h dev_video_bktr_ioctl_bt848_h dev_ic_bt8xx_h"
 dv1394_indev_deps="dv1394"
 dv1394_indev_select="dv_demuxer"
@@ -4312,10 +4311,6 @@ check_header AVFoundation/AVFoundation.h &&
     check_objcflags -fobjc-arc &&
     add_extralibs -framework Foundation -framework AVFoundation || \
     disable AVFoundation_AVFoundation_h
-
-check_header CoreVideo/CoreVideo.h &&
-    check_objcflags -fobjc-arc &&
-    add_extralibs -framework CoreVideo ||
 
 check_header sys/videoio.h
 

--- a/configure
+++ b/configure
@@ -1404,6 +1404,7 @@ HAVE_LIST_PUB="
 
 HEADERS_LIST="
     AVFoundation_AVFoundation_h
+    CoreVideo_CoreVideo_h
     alsa_asoundlib_h
     altivec_h
     arpa_inet_h
@@ -2137,7 +2138,7 @@ xwma_demuxer_select="riffdec"
 # indevs / outdevs
 alsa_indev_deps="alsa_asoundlib_h snd_pcm_htimestamp"
 alsa_outdev_deps="alsa_asoundlib_h"
-avfoundation_indev_deps="AVFoundation_AVFoundation_h"
+avfoundation_indev_deps="AVFoundation_AVFoundation_h CoreVideo_CoreVideo_h"
 bktr_indev_deps_any="dev_bktr_ioctl_bt848_h machine_ioctl_bt848_h dev_video_bktr_ioctl_bt848_h dev_ic_bt8xx_h"
 dv1394_indev_deps="dv1394"
 dv1394_indev_select="dv_demuxer"
@@ -4311,6 +4312,10 @@ check_header AVFoundation/AVFoundation.h &&
     check_objcflags -fobjc-arc &&
     add_extralibs -framework Foundation -framework AVFoundation || \
     disable AVFoundation_AVFoundation_h
+
+check_header CoreVideo/CoreVideo.h &&
+    check_objcflags -fobjc-arc &&
+    add_extralibs -framework CoreVideo ||
 
 check_header sys/videoio.h
 

--- a/configure
+++ b/configure
@@ -1978,7 +1978,7 @@ zmbv_encoder_deps="zlib"
 dxva2_deps="dxva2api_h"
 vaapi_deps="va_va_h"
 vda_deps="VideoDecodeAcceleration_VDADecoder_h pthreads"
-vda_extralibs="-framework CoreFoundation -framework VideoDecodeAcceleration -framework QuartzCore"
+vda_extralibs="-framework CoreFoundation -framework CoreMedia -framework CoreVideo -framework VideoDecodeAcceleration -framework QuartzCore"
 vdpau_deps="vdpau_vdpau_h vdpau_vdpau_x11_h"
 
 h263_vaapi_hwaccel_deps="vaapi"


### PR DESCRIPTION
What's new:

- basic pixel_format support: always fallback on first pixel format supported by the device
- fix device selection
- open, read, close video sessions
