### PR TITLE
preliminary patchset for libav 11.5

### DIFF
--- a/avconv_vda.c
+++ b/avconv_vda.c
@@ -76,6 +76,8 @@ static int vda_retrieve_data(AVCodecContext *s, AVFrame *frame)
                   data, linesize, vda->tmp_frame->format,
                   frame->width, frame->height);
 
+    CVPixelBufferUnlockBaseAddress(pixbuf, kCVPixelBufferLock_ReadOnly);
+
     ret = av_frame_copy_props(vda->tmp_frame, frame);
     if (ret < 0)
         return ret;

--- a/configure
+++ b/configure
@@ -2928,9 +2928,6 @@ probe_cc(){
         _ld_path='-libpath:'
         _flags='-nologo'
         _cflags='-D_USE_MATH_DEFINES -D_CRT_SECURE_NO_WARNINGS -Dinline=__inline -FIstdlib.h -Dstrtoll=_strtoi64'
-        if [ $pfx = hostcc ]; then
-            append _cflags -Dsnprintf=_snprintf
-        fi
     elif $_cc 2>&1 | grep -q Intel; then
         _type=icl
         _ident=$($cc 2>&1 | head -n1)
@@ -2954,9 +2951,6 @@ probe_cc(){
         # -Qvec- -Qsimd- to prevent miscompilation, -GS for consistency
         # with MSVC which enables it by default.
         _cflags='-D_USE_MATH_DEFINES -FIstdlib.h -Dstrtoll=_strtoi64 -Qms0 -Qvec- -Qsimd- -GS'
-        if [ $pfx = hostcc ]; then
-            append _cflags -Dsnprintf=_snprintf
-        fi
     elif $_cc --version 2>/dev/null | grep -q ^cparser; then
         _type=cparser
         _ident=$($_cc --version | head -n1)
@@ -3639,6 +3633,16 @@ probe_libc(){
             add_${pfx}cppflags -D__printf__=__gnu_printf__
     elif check_${pfx}cpp_condition crtversion.h "defined _VC_CRT_MAJOR_VERSION"; then
         eval ${pfx}libc_type=msvcrt
+        if check_${pfx}cpp_condition crtversion.h "_VC_CRT_MAJOR_VERSION < 14"; then
+            if [ "$pfx" = host_ ]; then
+                add_host_cppflags -Dsnprintf=_snprintf
+            else
+                add_compat strtod.o strtod=avpriv_strtod
+                add_compat msvcrt/snprintf.o snprintf=avpriv_snprintf   \
+                                             _snprintf=avpriv_snprintf  \
+                                             vsnprintf=avpriv_vsnprintf
+            fi
+        fi
         # The MSVC 2010 headers (Win 7.0 SDK) set _WIN32_WINNT to
         # 0x601 by default unless something else is set by the user.
         # This can easily lead to us detecting functions only present
@@ -3665,12 +3669,6 @@ test -n "$host_libc_type" && enable host_libc_$host_libc_type
 case $libc_type in
     bionic)
         add_compat strtod.o strtod=avpriv_strtod
-        ;;
-    msvcrt)
-        add_compat strtod.o strtod=avpriv_strtod
-        add_compat msvcrt/snprintf.o snprintf=avpriv_snprintf   \
-                                     _snprintf=avpriv_snprintf  \
-                                     vsnprintf=avpriv_vsnprintf
         ;;
 esac
 

--- a/configure
+++ b/configure
@@ -3852,7 +3852,7 @@ elif enabled arm; then
 
     if     check_cpp_condition stddef.h "defined __ARM_PCS_VFP"; then
         enable vfp_args
-    elif ! check_cpp_condition stddef.h "defined __ARM_PCS || defined __SOFTFP__"; then
+    elif ! check_cpp_condition stddef.h "defined __ARM_PCS || defined __SOFTFP__" && [ $target_os != darwin ]; then
         case "${cross_prefix:-$cc}" in
             *hardfloat*)         enable vfp_args;   fpabi=vfp ;;
             *) check_ld <<EOF && enable vfp_args && fpabi=vfp || fpabi=soft ;;

--- a/libavcodec/aacdec.c
+++ b/libavcodec/aacdec.c
@@ -2783,8 +2783,9 @@ static int aac_decode_frame_int(AVCodecContext *avctx, void *data,
         }
     }
 
-    if ((err = frame_configure_elements(avctx)) < 0)
-        goto fail;
+    if (avctx->channels)
+        if ((err = frame_configure_elements(avctx)) < 0)
+            goto fail;
 
     // The FF_PROFILE_AAC_* defines are all object_type - 1
     // This may lead to an undefined profile being signaled
@@ -2794,6 +2795,9 @@ static int aac_decode_frame_int(AVCodecContext *avctx, void *data,
     // parse
     while ((elem_type = get_bits(gb, 3)) != TYPE_END) {
         elem_id = get_bits(gb, 4);
+
+        if (!avctx->channels && elem_type != TYPE_PCE)
+            goto fail;
 
         if (elem_type < TYPE_DSE) {
             if (!(che=get_che(ac, elem_type, elem_id))) {
@@ -2879,6 +2883,11 @@ static int aac_decode_frame_int(AVCodecContext *avctx, void *data,
             err = AVERROR_INVALIDDATA;
             goto fail;
         }
+    }
+
+    if (!avctx->channels) {
+        *got_frame_ptr = 0;
+        return 0;
     }
 
     spectral_to_sample(ac);

--- a/libavcodec/aic.c
+++ b/libavcodec/aic.c
@@ -437,7 +437,7 @@ static av_cold int aic_decode_init(AVCodecContext *avctx)
     ctx->num_x_slices = (ctx->mb_width + 15) >> 4;
     ctx->slice_width  = 16;
     for (i = 1; i < 32; i++) {
-        if (!(ctx->mb_width % i) && (ctx->mb_width / i < 32)) {
+        if (!(ctx->mb_width % i) && (ctx->mb_width / i <= 32)) {
             ctx->slice_width  = ctx->mb_width / i;
             ctx->num_x_slices = i;
             break;

--- a/libavcodec/arm/videodsp_armv5te.S
+++ b/libavcodec/arm/videodsp_armv5te.S
@@ -23,9 +23,10 @@
 #include "libavutil/arm/asm.S"
 
 function ff_prefetch_arm, export=1
+1:
         subs            r2,  r2,  #1
         pld             [r0]
         add             r0,  r0,  r1
-        bne             X(ff_prefetch_arm)
+        bne             1b
         bx              lr
 endfunc

--- a/libavcodec/avcodec.h
+++ b/libavcodec/avcodec.h
@@ -1215,21 +1215,31 @@ typedef struct AVCodecContext {
     /* video only */
     /**
      * picture width / height.
+     *
+     * @note Those fields may not match the values of the last
+     * AVFrame outputted by avcodec_decode_video2 due frame
+     * reordering.
+     *
      * - encoding: MUST be set by user.
      * - decoding: May be set by the user before opening the decoder if known e.g.
      *             from the container. Some decoders will require the dimensions
      *             to be set by the caller. During decoding, the decoder may
-     *             overwrite those values as required.
+     *             overwrite those values as required while parsing the data.
      */
     int width, height;
 
     /**
      * Bitstream width / height, may be different from width/height e.g. when
      * the decoded frame is cropped before being output.
+     *
+     * @note Those field may not match the value of the last
+     * AVFrame outputted by avcodec_decode_video2 due frame
+     * reordering.
+     *
      * - encoding: unused
      * - decoding: May be set by the user before opening the decoder if known
      *             e.g. from the container. During decoding, the decoder may
-     *             overwrite those values as required.
+     *             overwrite those values as required while parsing the data.
      */
     int coded_width, coded_height;
 
@@ -1248,8 +1258,14 @@ typedef struct AVCodecContext {
      * Pixel format, see AV_PIX_FMT_xxx.
      * May be set by the demuxer if known from headers.
      * May be overriden by the decoder if it knows better.
+     *
+     * @note This field may not match the value of the last
+     * AVFrame outputted by avcodec_decode_video2 due frame
+     * reordering.
+     *
      * - encoding: Set by user.
-     * - decoding: Set by user if known, overridden by libavcodec if known
+     * - decoding: Set by user if known, overridden by libavcodec while
+     *             parsing the data.
      */
     enum AVPixelFormat pix_fmt;
 

--- a/libavcodec/bink.c
+++ b/libavcodec/bink.c
@@ -944,15 +944,32 @@ static int binkb_decode_plane(BinkContext *c, AVFrame *frame, GetBitContext *gb,
     return 0;
 }
 
+static int bink_put_pixels(BinkContext *c,
+                           uint8_t *dst, uint8_t *prev, int stride,
+                           uint8_t *ref_start,
+                           uint8_t *ref_end)
+{
+    int xoff     = get_value(c, BINK_SRC_X_OFF);
+    int yoff     = get_value(c, BINK_SRC_Y_OFF);
+    uint8_t *ref = prev + xoff + yoff * stride;
+    if (ref < ref_start || ref > ref_end) {
+        av_log(c->avctx, AV_LOG_ERROR, "Copy out of bounds @%d, %d\n",
+               xoff, yoff);
+        return AVERROR_INVALIDDATA;
+    }
+    c->hdsp.put_pixels_tab[1][0](dst, ref, stride, 8);
+
+    return 0;
+}
+
 static int bink_decode_plane(BinkContext *c, AVFrame *frame, GetBitContext *gb,
                              int plane_idx, int is_chroma)
 {
     int blk, ret;
     int i, j, bx, by;
-    uint8_t *dst, *prev, *ref, *ref_start, *ref_end;
+    uint8_t *dst, *prev, *ref_start, *ref_end;
     int v, col[2];
     const uint8_t *scan;
-    int xoff, yoff;
     LOCAL_ALIGNED_16(int16_t, block, [64]);
     LOCAL_ALIGNED_16(uint8_t, ublock, [64]);
     LOCAL_ALIGNED_16(int32_t, dctblock, [64]);
@@ -1074,15 +1091,10 @@ static int bink_decode_plane(BinkContext *c, AVFrame *frame, GetBitContext *gb,
                 prev += 8;
                 break;
             case MOTION_BLOCK:
-                xoff = get_value(c, BINK_SRC_X_OFF);
-                yoff = get_value(c, BINK_SRC_Y_OFF);
-                ref = prev + xoff + yoff * stride;
-                if (ref < ref_start || ref > ref_end) {
-                    av_log(c->avctx, AV_LOG_ERROR, "Copy out of bounds @%d, %d\n",
-                           bx*8 + xoff, by*8 + yoff);
-                    return AVERROR_INVALIDDATA;
-                }
-                c->hdsp.put_pixels_tab[1][0](dst, ref, stride, 8);
+                ret = bink_put_pixels(c, dst, prev, stride,
+                                      ref_start, ref_end);
+                if (ret < 0)
+                    return ret;
                 break;
             case RUN_BLOCK:
                 scan = bink_patterns[get_bits(gb, 4)];
@@ -1108,15 +1120,10 @@ static int bink_decode_plane(BinkContext *c, AVFrame *frame, GetBitContext *gb,
                     dst[coordmap[*scan++]] = get_value(c, BINK_SRC_COLORS);
                 break;
             case RESIDUE_BLOCK:
-                xoff = get_value(c, BINK_SRC_X_OFF);
-                yoff = get_value(c, BINK_SRC_Y_OFF);
-                ref = prev + xoff + yoff * stride;
-                if (ref < ref_start || ref > ref_end) {
-                    av_log(c->avctx, AV_LOG_ERROR, "Copy out of bounds @%d, %d\n",
-                           bx*8 + xoff, by*8 + yoff);
-                    return AVERROR_INVALIDDATA;
-                }
-                c->hdsp.put_pixels_tab[1][0](dst, ref, stride, 8);
+                ret = bink_put_pixels(c, dst, prev, stride,
+                                      ref_start, ref_end);
+                if (ret < 0)
+                    return ret;
                 c->bdsp.clear_block(block);
                 v = get_bits(gb, 7);
                 read_residue(gb, block, v);
@@ -1133,10 +1140,10 @@ static int bink_decode_plane(BinkContext *c, AVFrame *frame, GetBitContext *gb,
                 c->bdsp.fill_block_tab[1](dst, v, stride, 8);
                 break;
             case INTER_BLOCK:
-                xoff = get_value(c, BINK_SRC_X_OFF);
-                yoff = get_value(c, BINK_SRC_Y_OFF);
-                ref = prev + xoff + yoff * stride;
-                c->hdsp.put_pixels_tab[1][0](dst, ref, stride, 8);
+                ret = bink_put_pixels(c, dst, prev, stride,
+                                      ref_start, ref_end);
+                if (ret < 0)
+                    return ret;
                 memset(dctblock, 0, sizeof(*dctblock) * 64);
                 dctblock[0] = get_value(c, BINK_SRC_INTER_DC);
                 read_dct_coeffs(gb, dctblock, bink_scan, bink_inter_quant, -1);

--- a/libavcodec/bytestream.h
+++ b/libavcodec/bytestream.h
@@ -70,8 +70,10 @@ static av_always_inline type bytestream2_get_ ## name ## u(GetByteContext *g)  \
 }                                                                              \
 static av_always_inline type bytestream2_get_ ## name(GetByteContext *g)       \
 {                                                                              \
-    if (g->buffer_end - g->buffer < bytes)                                     \
+    if (g->buffer_end - g->buffer < bytes) {                                   \
+        g->buffer = g->buffer_end;                                             \
         return 0;                                                              \
+    }                                                                          \
     return bytestream2_get_ ## name ## u(g);                                   \
 }                                                                              \
 static av_always_inline type bytestream2_peek_ ## name(GetByteContext *g)      \

--- a/libavcodec/dvdsubdec.c
+++ b/libavcodec/dvdsubdec.c
@@ -178,13 +178,14 @@ static void guess_palette(DVDSubContext* ctx,
 static int decode_dvd_subtitles(DVDSubContext *ctx, AVSubtitle *sub_header,
                                 const uint8_t *buf, int buf_size)
 {
-    int cmd_pos, pos, cmd, x1, y1, x2, y2, offset1, offset2, next_cmd_pos;
+    int cmd_pos, pos, cmd, x1, y1, x2, y2, next_cmd_pos;
     int big_offsets, offset_size, is_8bit = 0;
     const uint8_t *yuv_palette = 0;
     uint8_t colormap[4] = { 0 }, alpha[256] = { 0 };
     int date;
     int i;
     int is_menu = 0;
+    int64_t offset1, offset2;
 
     if (buf_size < 10)
         return -1;
@@ -302,6 +303,9 @@ static int decode_dvd_subtitles(DVDSubContext *ctx, AVSubtitle *sub_header,
             }
         }
     the_end:
+        if (offset1 >= buf_size || offset2 >= buf_size)
+            goto fail;
+
         if (offset1 >= 0) {
             int w, h;
             uint8_t *bitmap;

--- a/libavcodec/flashsv.c
+++ b/libavcodec/flashsv.c
@@ -339,12 +339,14 @@ static int flashsv_decode_frame(AVCodecContext *avctx, void *data,
     s->is_keyframe = (avpkt->flags & AV_PKT_FLAG_KEY) && (s->ver == 2);
     if (s->is_keyframe) {
         int err;
+        int nb_blocks = (v_blocks + !!v_part) *
+                        (h_blocks + !!h_part) * sizeof(s->blocks[0]);
         if ((err = av_reallocp(&s->keyframedata, avpkt->size)) < 0)
             return err;
         memcpy(s->keyframedata, avpkt->data, avpkt->size);
-        if ((err = av_reallocp(&s->blocks, (v_blocks + !!v_part) *
-                               (h_blocks + !!h_part) * sizeof(s->blocks[0]))) < 0)
+        if ((err = av_reallocp(&s->blocks, nb_blocks)) < 0)
             return err;
+        memset(s->blocks, 0, nb_blocks);
     }
 
     av_dlog(avctx, "image: %dx%d block: %dx%d num: %dx%d part: %dx%d\n",

--- a/libavcodec/g726.c
+++ b/libavcodec/g726.c
@@ -23,7 +23,6 @@
  */
 #include <limits.h>
 
-#include "libavutil/avassert.h"
 #include "libavutil/channel_layout.h"
 #include "libavutil/opt.h"
 #include "avcodec.h"
@@ -315,7 +314,11 @@ static av_cold int g726_encode_init(AVCodecContext *avctx)
                "Resample or reduce the compliance level.\n");
         return AVERROR(EINVAL);
     }
-    av_assert0(avctx->sample_rate > 0);
+    if (avctx->sample_rate <= 0) {
+        av_log(avctx, AV_LOG_ERROR, "Invalid sample rate %d\n",
+               avctx->sample_rate);
+        return AVERROR(EINVAL);
+    }
 
     if(avctx->channels != 1){
         av_log(avctx, AV_LOG_ERROR, "Only mono is supported\n");

--- a/libavcodec/h261enc.c
+++ b/libavcodec/h261enc.c
@@ -69,8 +69,8 @@ void ff_h261_encode_picture_header(MpegEncContext *s, int picture_number)
 
     put_bits(&s->pb, 1, format); /* 0 == QCIF, 1 == CIF */
 
-    put_bits(&s->pb, 1, 0); /* still image mode */
-    put_bits(&s->pb, 1, 0); /* reserved */
+    put_bits(&s->pb, 1, 1); /* still image mode */
+    put_bits(&s->pb, 1, 1); /* reserved */
 
     put_bits(&s->pb, 1, 0); /* no PEI */
     if (format == 0)

--- a/libavcodec/h261enc.c
+++ b/libavcodec/h261enc.c
@@ -63,7 +63,7 @@ void ff_h261_encode_picture_header(MpegEncContext *s, int picture_number)
 
     put_bits(&s->pb, 1, 0); /* split screen off */
     put_bits(&s->pb, 1, 0); /* camera  off */
-    put_bits(&s->pb, 1, 0); /* freeze picture release off */
+    put_bits(&s->pb, 1, s->pict_type == AV_PICTURE_TYPE_I); /* freeze picture release on/off */
 
     format = ff_h261_get_picture_format(s->width, s->height);
 

--- a/libavcodec/h264_refs.c
+++ b/libavcodec/h264_refs.c
@@ -636,6 +636,15 @@ int ff_h264_execute_ref_pic_marking(H264Context *h, MMCO *mmco, int mmco_count)
             if (h->short_ref[0] == h->cur_pic_ptr)
                 remove_short_at_index(h, 0);
 
+            /* make sure the current picture is not already assigned as a long ref */
+            if (h->cur_pic_ptr->long_ref) {
+                for (j = 0; j < FF_ARRAY_ELEMS(h->long_ref); j++) {
+                    if (h->long_ref[j] == h->cur_pic_ptr)
+                        remove_long(h, j, 0);
+                }
+            }
+
+
             if (h->long_ref[mmco[i].long_arg] != h->cur_pic_ptr) {
                 remove_long(h, mmco[i].long_arg, 0);
 

--- a/libavcodec/imgconvert.c
+++ b/libavcodec/imgconvert.c
@@ -78,7 +78,7 @@ int avcodec_get_pix_fmt_loss(enum AVPixelFormat dst_pix_fmt,
         loss |= FF_LOSS_COLORSPACE;
 
     if (has_alpha && !(dst_desc->flags & AV_PIX_FMT_FLAG_ALPHA) &&
-         (dst_desc->flags & AV_PIX_FMT_FLAG_ALPHA))
+         (src_desc->flags & AV_PIX_FMT_FLAG_ALPHA))
         loss |= FF_LOSS_ALPHA;
 
     if (dst_pix_fmt == AV_PIX_FMT_PAL8 && !is_gray(src_desc))

--- a/libavcodec/lagarithrac.c
+++ b/libavcodec/lagarithrac.c
@@ -45,7 +45,7 @@ void ff_lag_rac_init(lag_rac *l, GetBitContext *gb, int length)
 
     l->range        = 0x80;
     l->low          = *l->bytestream >> 1;
-    l->hash_shift   = FFMAX(l->scale - 8, 0);
+    l->hash_shift   = FFMAX(l->scale, 8) - 8;
 
     for (i = j = 0; i < 256; i++) {
         unsigned r = i << l->hash_shift;

--- a/libavcodec/mimic.c
+++ b/libavcodec/mimic.c
@@ -436,10 +436,9 @@ static int mimic_decode_frame(AVCodecContext *avctx, void *data,
     res = decode(ctx, quality, num_coeffs, !is_pframe);
     ff_thread_report_progress(&ctx->frames[ctx->cur_index], INT_MAX, 0);
     if (res < 0) {
-        if (!(avctx->active_thread_type & FF_THREAD_FRAME)) {
+        if (!(avctx->active_thread_type & FF_THREAD_FRAME))
             ff_thread_release_buffer(avctx, &ctx->frames[ctx->cur_index]);
-            return res;
-        }
+        return res;
     }
 
     if ((res = av_frame_ref(data, ctx->frames[ctx->cur_index].f)) < 0)

--- a/libavcodec/mmvideo.c
+++ b/libavcodec/mmvideo.c
@@ -99,7 +99,8 @@ static int mm_decode_intra(MmContext * s, int half_horiz, int half_vert)
     while (bytestream2_get_bytes_left(&s->gb) > 0) {
         int run_length, color;
 
-        if (y >= s->avctx->height)
+        // writes one more line when half_vert is true
+        if (y >= s->avctx->height + !!half_vert)
             return 0;
 
         color = bytestream2_get_byte(&s->gb);
@@ -112,6 +113,9 @@ static int mm_decode_intra(MmContext * s, int half_horiz, int half_vert)
 
         if (half_horiz)
             run_length *=2;
+
+        if (s->avctx->width - x < run_length)
+            return AVERROR_INVALIDDATA;
 
         if (color) {
             memset(s->frame->data[0] + y*s->frame->linesize[0] + x, color, run_length);

--- a/libavcodec/opusdec.c
+++ b/libavcodec/opusdec.c
@@ -567,8 +567,8 @@ static int opus_decode_packet(AVCodecContext *avctx, void *data,
         if (buffer_samples) {
             float *buf[2] = { c->out[2 * i + 0] ? c->out[2 * i + 0] : (float*)frame->extended_data[0],
                               c->out[2 * i + 1] ? c->out[2 * i + 1] : (float*)frame->extended_data[0] };
-            buf[0] += buffer_samples;
-            buf[1] += buffer_samples;
+            buf[0] += decoded_samples;
+            buf[1] += decoded_samples;
             ret = av_audio_fifo_write(c->sync_buffers[i], (void**)buf, buffer_samples);
             if (ret < 0)
                 return ret;

--- a/libavcodec/rpza.c
+++ b/libavcodec/rpza.c
@@ -52,23 +52,25 @@ typedef struct RpzaContext {
     GetByteContext gb;
 } RpzaContext;
 
-#define ADVANCE_BLOCK() \
-{ \
-    pixel_ptr += 4; \
-    if (pixel_ptr >= width) \
-    { \
-        pixel_ptr = 0; \
-        row_ptr += stride * 4; \
-    } \
-    total_blocks--; \
-    if (total_blocks < 0) \
-    { \
-        av_log(s->avctx, AV_LOG_ERROR, "warning: block counter just went negative (this should not happen)\n"); \
-        return; \
-    } \
-}
+#define CHECK_BLOCK()                                                         \
+    if (total_blocks < 1) {                                                    \
+        av_log(s->avctx, AV_LOG_ERROR,                                         \
+               "Block counter just went negative (this should not happen)\n"); \
+        return AVERROR_INVALIDDATA;                                            \
+    }                                                                          \
 
-static void rpza_decode_stream(RpzaContext *s)
+#define ADVANCE_BLOCK()             \
+    {                               \
+        pixel_ptr += 4;             \
+        if (pixel_ptr >= width)     \
+        {                           \
+            pixel_ptr = 0;          \
+            row_ptr  += stride * 4; \
+        }                           \
+        total_blocks--;             \
+    }
+
+static int rpza_decode_stream(RpzaContext *s)
 {
     int width = s->avctx->width;
     int stride = s->frame->linesize[0] / 2;
@@ -126,7 +128,8 @@ static void rpza_decode_stream(RpzaContext *s)
         /* Skip blocks */
         case 0x80:
             while (n_blocks--) {
-              ADVANCE_BLOCK();
+                CHECK_BLOCK();
+                ADVANCE_BLOCK();
             }
             break;
 
@@ -134,6 +137,7 @@ static void rpza_decode_stream(RpzaContext *s)
         case 0xa0:
             colorA = bytestream2_get_be16(&s->gb);
             while (n_blocks--) {
+                CHECK_BLOCK();
                 block_ptr = row_ptr + pixel_ptr;
                 for (pixel_y = 0; pixel_y < 4; pixel_y++) {
                     for (pixel_x = 0; pixel_x < 4; pixel_x++){
@@ -177,8 +181,9 @@ static void rpza_decode_stream(RpzaContext *s)
             color4[2] |= ((21 * ta + 11 * tb) >> 5);
 
             if (bytestream2_get_bytes_left(&s->gb) < n_blocks * 4)
-                return;
+                return AVERROR_INVALIDDATA;
             while (n_blocks--) {
+                CHECK_BLOCK();
                 block_ptr = row_ptr + pixel_ptr;
                 for (pixel_y = 0; pixel_y < 4; pixel_y++) {
                     uint8_t index = bytestream2_get_byteu(&s->gb);
@@ -196,7 +201,8 @@ static void rpza_decode_stream(RpzaContext *s)
         /* Fill block with 16 colors */
         case 0x00:
             if (bytestream2_get_bytes_left(&s->gb) < 30)
-                return;
+                return AVERROR_INVALIDDATA;
+            CHECK_BLOCK();
             block_ptr = row_ptr + pixel_ptr;
             for (pixel_y = 0; pixel_y < 4; pixel_y++) {
                 for (pixel_x = 0; pixel_x < 4; pixel_x++){
@@ -216,9 +222,11 @@ static void rpza_decode_stream(RpzaContext *s)
             av_log(s->avctx, AV_LOG_ERROR, "Unknown opcode %d in rpza chunk."
                  " Skip remaining %d bytes of chunk data.\n", opcode,
                  bytestream2_get_bytes_left(&s->gb));
-            return;
+            return AVERROR_INVALIDDATA;
         } /* Opcode switch */
     }
+
+    return 0;
 }
 
 static av_cold int rpza_decode_init(AVCodecContext *avctx)
@@ -249,7 +257,9 @@ static int rpza_decode_frame(AVCodecContext *avctx,
         return ret;
     }
 
-    rpza_decode_stream(s);
+    ret = rpza_decode_stream(s);
+    if (ret < 0)
+        return ret;
 
     if ((ret = av_frame_ref(data, s->frame)) < 0)
         return ret;

--- a/libavcodec/truemotion2.c
+++ b/libavcodec/truemotion2.c
@@ -281,7 +281,7 @@ static int tm2_read_stream(TM2Context *ctx, const uint8_t *buf, int stream_id, i
     if (len == 0)
         return 4;
 
-    if (len >= INT_MAX/4-1 || len < 0 || len > buf_size) {
+    if (len >= INT_MAX / 4 - 1 || len < 0 || skip > buf_size) {
         av_log(ctx->avctx, AV_LOG_ERROR, "Error, invalid stream size.\n");
         return AVERROR_INVALIDDATA;
     }

--- a/libavcodec/vp8.c
+++ b/libavcodec/vp8.c
@@ -474,6 +474,10 @@ static int vp7_decode_frame_header(VP8Context *s, const uint8_t *buf, int buf_si
     int width  = s->avctx->width;
     int height = s->avctx->height;
 
+    if (buf_size < 4) {
+        return AVERROR_INVALIDDATA;
+    }
+
     s->profile = (buf[0] >> 1) & 7;
     if (s->profile > 1) {
         avpriv_request_sample(s->avctx, "Unknown profile %d", s->profile);
@@ -486,6 +490,10 @@ static int vp7_decode_frame_header(VP8Context *s, const uint8_t *buf, int buf_si
 
     buf      += 4 - s->profile;
     buf_size -= 4 - s->profile;
+
+    if (buf_size < part1_size) {
+        return AVERROR_INVALIDDATA;
+    }
 
     memcpy(s->put_pixels_tab, s->vp8dsp.put_vp8_epel_pixels_tab, sizeof(s->put_pixels_tab));
 

--- a/libavcodec/webp.c
+++ b/libavcodec/webp.c
@@ -1362,7 +1362,7 @@ static int webp_decode_frame(AVCodecContext *avctx, void *data, int *got_frame,
         return AVERROR_INVALIDDATA;
     }
 
-    while (bytestream2_get_bytes_left(&gb) > 0) {
+    while (bytestream2_get_bytes_left(&gb) > 8) {
         char chunk_str[5] = { 0 };
 
         chunk_type = bytestream2_get_le32(&gb);

--- a/libavcodec/x86/h264_weight.asm
+++ b/libavcodec/x86/h264_weight.asm
@@ -135,6 +135,16 @@ WEIGHT_FUNC_HALF_MM 8, 8
     add  off_regd, 1
     or   off_regd, 1
     add        r4, 1
+    cmp        r6d, 128
+    je .nonnormal
+    cmp        r5, 128
+    jne .normal
+.nonnormal
+    sar        r5, 1
+    sar        r6, 1
+    sar  off_regd, 1
+    sub        r4, 1
+.normal
 %if cpuflag(ssse3)
     movd       m4, r5d
     movd       m0, r6d

--- a/libavdevice/jack_audio.c
+++ b/libavdevice/jack_audio.c
@@ -199,6 +199,10 @@ static int start_jack(AVFormatContext *context)
     self->filled_pkts = av_fifo_alloc(FIFO_PACKETS_NUM * sizeof(AVPacket));
     /* New packets FIFO with one extra packet for safety against underruns */
     self->new_pkts    = av_fifo_alloc((FIFO_PACKETS_NUM + 1) * sizeof(AVPacket));
+    if (!self->new_pkts) {
+        jack_client_close(self->client);
+        return AVERROR(ENOMEM);
+    }
     if ((test = supply_new_packets(self, context))) {
         jack_client_close(self->client);
         return test;

--- a/libavfilter/af_channelmap.c
+++ b/libavfilter/af_channelmap.c
@@ -57,7 +57,6 @@ enum MappingMode {
 #define MAX_CH 64
 typedef struct ChannelMapContext {
     const AVClass *class;
-    AVFilterChannelLayouts *channel_layouts;
     char *mapping_str;
     char *channel_layout_str;
     uint64_t output_layout;
@@ -276,8 +275,6 @@ static av_cold int channelmap_init(AVFilterContext *ctx)
         return AVERROR(EINVAL);
     }
 
-    ff_add_channel_layout(&s->channel_layouts, s->output_layout);
-
     if (mode == MAP_PAIR_INT_STR || mode == MAP_PAIR_STR_STR) {
         for (i = 0; i < s->nch; i++) {
             s->map[i].out_channel_idx = av_get_channel_layout_channel_index(
@@ -291,11 +288,14 @@ static av_cold int channelmap_init(AVFilterContext *ctx)
 static int channelmap_query_formats(AVFilterContext *ctx)
 {
     ChannelMapContext *s = ctx->priv;
+    AVFilterChannelLayouts *channel_layouts = NULL;
+
+    ff_add_channel_layout(&channel_layouts, s->output_layout);
 
     ff_set_common_formats(ctx, ff_planar_sample_fmts());
     ff_set_common_samplerates(ctx, ff_all_samplerates());
     ff_channel_layouts_ref(ff_all_channel_layouts(), &ctx->inputs[0]->out_channel_layouts);
-    ff_channel_layouts_ref(s->channel_layouts,       &ctx->outputs[0]->in_channel_layouts);
+    ff_channel_layouts_ref(channel_layouts,          &ctx->outputs[0]->in_channel_layouts);
 
     return 0;
 }

--- a/libavformat/audiointerleave.c
+++ b/libavformat/audiointerleave.c
@@ -127,7 +127,7 @@ int ff_audio_rechunk_interleave(AVFormatContext *s, AVPacket *out, AVPacket *pkt
     for (i = 0; i < s->nb_streams; i++) {
         AVStream *st = s->streams[i];
         if (st->codec->codec_type == AVMEDIA_TYPE_AUDIO) {
-            AVPacket new_pkt;
+            AVPacket new_pkt = { 0 };
             while (interleave_new_audio_packet(s, &new_pkt, i, flush))
                 if ((ret = ff_interleave_add_packet(s, &new_pkt, compare_ts)) < 0)
                     return ret;

--- a/libavformat/file.c
+++ b/libavformat/file.c
@@ -59,13 +59,15 @@ static const AVClass file_class = {
 static int file_read(URLContext *h, unsigned char *buf, int size)
 {
     FileContext *c = h->priv_data;
-    return read(c->fd, buf, size);
+    int ret = read(c->fd, buf, size);
+    return (ret == -1) ? AVERROR(errno) : ret;
 }
 
 static int file_write(URLContext *h, const unsigned char *buf, int size)
 {
     FileContext *c = h->priv_data;
-    return write(c->fd, buf, size);
+    int ret = write(c->fd, buf, size);
+    return (ret == -1) ? AVERROR(errno) : ret;
 }
 
 static int file_get_handle(URLContext *h)

--- a/libavformat/matroskaenc.c
+++ b/libavformat/matroskaenc.c
@@ -1584,7 +1584,7 @@ static int mkv_write_flush_packet(AVFormatContext *s, AVPacket *pkt)
                 mkv_flush_dynbuf(s);
             avio_flush(s->pb);
         }
-        return 0;
+        return 1;
     }
     return mkv_write_packet(s, pkt);
 }

--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -1440,7 +1440,11 @@ static int mov_finalize_stsd_codec(MOVContext *c, AVIOContext *pb,
     switch (st->codec->codec_id) {
 #if CONFIG_DV_DEMUXER
     case AV_CODEC_ID_DVAUDIO:
-        c->dv_fctx  = avformat_alloc_context();
+        c->dv_fctx = avformat_alloc_context();
+        if (!c->dv_fctx) {
+            av_log(c->fc, AV_LOG_ERROR, "dv demux context alloc error\n");
+            return AVERROR(ENOMEM);
+        }
         c->dv_demux = avpriv_dv_init_demux(c->dv_fctx);
         if (!c->dv_demux) {
             av_log(c->fc, AV_LOG_ERROR, "dv demux context init error\n");

--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -1880,7 +1880,7 @@ static int mov_read_ctts(MOVContext *c, AVIOContext *pb, MOVAtom atom)
         return 0;
     if (entries >= UINT_MAX / sizeof(*sc->ctts_data))
         return AVERROR_INVALIDDATA;
-    sc->ctts_data = av_malloc(entries * sizeof(*sc->ctts_data));
+    sc->ctts_data = av_realloc(NULL, entries * sizeof(*sc->ctts_data));
     if (!sc->ctts_data)
         return AVERROR(ENOMEM);
 

--- a/libavformat/mov.c
+++ b/libavformat/mov.c
@@ -1790,10 +1790,11 @@ static int mov_read_stsz(MOVContext *c, AVIOContext *pb, MOVAtom atom)
 
     sc->sample_count = i;
 
+    av_free(buf);
+
     if (pb->eof_reached)
         return AVERROR_EOF;
 
-    av_free(buf);
     return 0;
 }
 
@@ -1875,6 +1876,8 @@ static int mov_read_ctts(MOVContext *c, AVIOContext *pb, MOVAtom atom)
     entries = avio_rb32(pb);
 
     av_dlog(c->fc, "track[%i].ctts.entries = %i\n", c->fc->nb_streams-1, entries);
+
+    av_freep(&sc->ctts_data);
 
     if (!entries)
         return 0;

--- a/libavformat/movenc.c
+++ b/libavformat/movenc.c
@@ -1713,7 +1713,7 @@ static int mov_write_track_udta_tag(AVIOContext *pb, MOVMuxContext *mov,
     int ret, size;
     uint8_t *buf;
 
-    if (!st || mov->fc->flags & AVFMT_FLAG_BITEXACT)
+    if (!st)
         return 0;
 
     ret = avio_open_dyn_buf(&pb_buf);
@@ -1991,8 +1991,10 @@ static int mov_write_ilst_tag(AVIOContext *pb, MOVMuxContext *mov,
     mov_write_string_metadata(s, pb, "\251wrt", "composer" , 1);
     mov_write_string_metadata(s, pb, "\251alb", "album"    , 1);
     mov_write_string_metadata(s, pb, "\251day", "date"     , 1);
-    if (!mov_write_string_metadata(s, pb, "\251too", "encoding_tool", 1))
-        mov_write_string_tag(pb, "\251too", LIBAVFORMAT_IDENT, 0, 1);
+    if (!mov_write_string_metadata(s, pb, "\251too", "encoding_tool", 1)) {
+        if (!(s->flags & AVFMT_FLAG_BITEXACT))
+            mov_write_string_tag(pb, "\251too", LIBAVFORMAT_IDENT, 0, 1);
+    }
     mov_write_string_metadata(s, pb, "\251cmt", "comment"  , 1);
     mov_write_string_metadata(s, pb, "\251gen", "genre"    , 1);
     mov_write_string_metadata(s, pb, "\251cpy", "copyright", 1);
@@ -2095,9 +2097,6 @@ static int mov_write_udta_tag(AVIOContext *pb, MOVMuxContext *mov,
     int ret, size;
     uint8_t *buf;
 
-    if (s->flags & AVFMT_FLAG_BITEXACT)
-        return 0;
-
     ret = avio_open_dyn_buf(&pb_buf);
     if (ret < 0)
         return ret;
@@ -2117,7 +2116,8 @@ static int mov_write_udta_tag(AVIOContext *pb, MOVMuxContext *mov,
         mov_write_string_metadata(s, pb_buf, "\251aut", "author",      0);
         mov_write_string_metadata(s, pb_buf, "\251alb", "album",       0);
         mov_write_string_metadata(s, pb_buf, "\251day", "date",        0);
-        mov_write_string_metadata(s, pb_buf, "\251swr", "encoder",     0);
+        if (!(s->flags & AVFMT_FLAG_BITEXACT))
+            mov_write_string_metadata(s, pb_buf, "\251swr", "encoder", 0);
         mov_write_string_metadata(s, pb_buf, "\251des", "comment",     0);
         mov_write_string_metadata(s, pb_buf, "\251gen", "genre",       0);
         mov_write_string_metadata(s, pb_buf, "\251cpy", "copyright",   0);

--- a/libavformat/msnwc_tcp.c
+++ b/libavformat/msnwc_tcp.c
@@ -104,6 +104,7 @@ static int msnwc_tcp_read_packet(AVFormatContext *ctx, AVPacket *pkt)
     AVIOContext *pb = ctx->pb;
     uint16_t keyframe;
     uint32_t size, timestamp;
+    int ret;
 
     avio_skip(pb, 1); /* one byte has been read ahead */
     avio_skip(pb, 2);
@@ -114,8 +115,11 @@ static int msnwc_tcp_read_packet(AVFormatContext *ctx, AVPacket *pkt)
     avio_skip(pb, 4);
     timestamp = avio_rl32(pb);
 
-    if(!size || av_get_packet(pb, pkt, size) != size)
-        return -1;
+    if (!size)
+        return AVERROR_INVALIDDATA;
+
+    if ((ret = av_get_packet(pb, pkt, size)) < 0)
+        return ret;
 
     avio_skip(pb, 1); /* Read ahead one byte of struct size like read_header */
 

--- a/libavformat/mux.c
+++ b/libavformat/mux.c
@@ -333,8 +333,12 @@ static int write_packet(AVFormatContext *s, AVPacket *pkt)
     }
     ret = s->oformat->write_packet(s, pkt);
 
-    if (s->pb && ret >= 0 && s->flags & AVFMT_FLAG_FLUSH_PACKETS)
-        avio_flush(s->pb);
+    if (s->pb && ret >= 0) {
+        if (s->flags & AVFMT_FLAG_FLUSH_PACKETS)
+            avio_flush(s->pb);
+        if (s->pb->error < 0)
+            ret = s->pb->error;
+    }
 
     return ret;
 }

--- a/libavformat/nutenc.c
+++ b/libavformat/nutenc.c
@@ -436,7 +436,8 @@ static int write_streamheader(AVFormatContext *avctx, AVIOContext *bc,
     }
     ff_put_v(bc, 4);
 
-    if (!codec_tag || codec->codec_id == AV_CODEC_ID_RAWVIDEO)
+    if (av_codec_get_id(ff_nut_codec_tags, codec->codec_tag) == codec->codec_id ||
+        !codec_tag || codec->codec_id == AV_CODEC_ID_RAWVIDEO)
         codec_tag = codec->codec_tag;
 
     if (codec_tag) {

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1083,7 +1083,6 @@ int ff_rtsp_read_reply(AVFormatContext *s, RTSPMessageHeader *reply,
     unsigned char ch;
     const char *p;
     int ret, content_length, line_count = 0, request = 0;
-    int first_line = 1;
     unsigned char *content = NULL;
 
 start:
@@ -1103,7 +1102,7 @@ start:
                 return AVERROR_EOF;
             if (ch == '\n')
                 break;
-            if (ch == '$' && first_line && q == buf) {
+            if (ch == '$' && q == buf) {
                 if (return_on_interleaved_data) {
                     return 1;
                 } else
@@ -1114,7 +1113,6 @@ start:
             }
         }
         *q = '\0';
-        first_line = 0;
 
         av_dlog(s, "line='%s'\n", buf);
 

--- a/libavformat/rtsp.c
+++ b/libavformat/rtsp.c
@@ -1083,6 +1083,7 @@ int ff_rtsp_read_reply(AVFormatContext *s, RTSPMessageHeader *reply,
     unsigned char ch;
     const char *p;
     int ret, content_length, line_count = 0, request = 0;
+    int first_line = 1;
     unsigned char *content = NULL;
 
 start:
@@ -1102,8 +1103,7 @@ start:
                 return AVERROR_EOF;
             if (ch == '\n')
                 break;
-            if (ch == '$') {
-                /* XXX: only parse it if first char on line ? */
+            if (ch == '$' && first_line && q == buf) {
                 if (return_on_interleaved_data) {
                     return 1;
                 } else
@@ -1114,6 +1114,7 @@ start:
             }
         }
         *q = '\0';
+        first_line = 0;
 
         av_dlog(s, "line='%s'\n", buf);
 

--- a/libavformat/sctp.c
+++ b/libavformat/sctp.c
@@ -115,7 +115,7 @@ static int ff_sctp_recvmsg(int s, void *msg, size_t len, struct sockaddr *from,
 static int ff_sctp_send(int s, const void *msg, size_t len,
                         const struct sctp_sndrcvinfo *sinfo, int flags)
 {
-    struct msghdr outmsg;
+    struct msghdr outmsg = { 0 };
     struct iovec iov;
 
     outmsg.msg_name       = NULL;

--- a/libavutil/internal.h
+++ b/libavutil/internal.h
@@ -134,11 +134,6 @@
 
 #include "libm.h"
 
-#if defined(_MSC_VER)
-#pragma comment(linker, "/include:"EXTERN_PREFIX"avpriv_strtod")
-#pragma comment(linker, "/include:"EXTERN_PREFIX"avpriv_snprintf")
-#endif
-
 /**
  * Return NULL if CONFIG_SMALL is true, otherwise the argument
  * without modification. Used to disable the definition of strings
@@ -212,6 +207,12 @@ void avpriv_request_sample(void *avc,
                            const char *msg, ...) av_printf_format(2, 3);
 
 #if HAVE_LIBC_MSVCRT
+#include <crtversion.h>
+#if defined(_VC_CRT_MAJOR_VERSION) && _VC_CRT_MAJOR_VERSION < 14
+#pragma comment(linker, "/include:"EXTERN_PREFIX"avpriv_strtod")
+#pragma comment(linker, "/include:"EXTERN_PREFIX"avpriv_snprintf")
+#endif
+
 #define avpriv_open ff_open
 #endif
 

--- a/tests/ref/vsynth/vsynth1-h261
+++ b/tests/ref/vsynth/vsynth1-h261
@@ -1,4 +1,4 @@
-34263080870c91c5e6c3c7dca799c50d *tests/data/fate/vsynth1-h261.avi
+e7adc829541417888df4ac031768679f *tests/data/fate/vsynth1-h261.avi
 707576 tests/data/fate/vsynth1-h261.avi
 716e83cb51afb1246bfaa80967df48ea *tests/data/fate/vsynth1-h261.out.rawvideo
 stddev:    9.11 PSNR: 28.93 MAXDIFF:  113 bytes:  7603200/  7603200

--- a/tests/ref/vsynth/vsynth1-h261
+++ b/tests/ref/vsynth/vsynth1-h261
@@ -1,4 +1,4 @@
-d3397557ad8a02d28cb5feeb0b51e5c8 *tests/data/fate/vsynth1-h261.avi
+34263080870c91c5e6c3c7dca799c50d *tests/data/fate/vsynth1-h261.avi
 707576 tests/data/fate/vsynth1-h261.avi
 716e83cb51afb1246bfaa80967df48ea *tests/data/fate/vsynth1-h261.out.rawvideo
 stddev:    9.11 PSNR: 28.93 MAXDIFF:  113 bytes:  7603200/  7603200

--- a/tests/ref/vsynth/vsynth1-mpeg4
+++ b/tests/ref/vsynth/vsynth1-mpeg4
@@ -1,4 +1,4 @@
-dc927acd770e19a97456ecbd4d786938 *tests/data/fate/vsynth1-mpeg4.mp4
-540180 tests/data/fate/vsynth1-mpeg4.mp4
+173f524d5cd2591709bf1d5d2818b420 *tests/data/fate/vsynth1-mpeg4.mp4
+540241 tests/data/fate/vsynth1-mpeg4.mp4
 8828a375448dc5c2215163ba70656f89 *tests/data/fate/vsynth1-mpeg4.out.rawvideo
 stddev:    7.97 PSNR: 30.10 MAXDIFF:  105 bytes:  7603200/  7603200

--- a/tests/ref/vsynth/vsynth2-h261
+++ b/tests/ref/vsynth/vsynth2-h261
@@ -1,4 +1,4 @@
-70e9342de71456cd6fbe9a771cceefd5 *tests/data/fate/vsynth2-h261.avi
+0292ca022247f978f6e894831310682b *tests/data/fate/vsynth2-h261.avi
 257928 tests/data/fate/vsynth2-h261.avi
 1a9bb0d52bd24cb62162c5e3c2aed317 *tests/data/fate/vsynth2-h261.out.rawvideo
 stddev:    7.21 PSNR: 30.97 MAXDIFF:   96 bytes:  7603200/  7603200

--- a/tests/ref/vsynth/vsynth2-h261
+++ b/tests/ref/vsynth/vsynth2-h261
@@ -1,4 +1,4 @@
-b5187bd5be8b422ff220f297de90fbcb *tests/data/fate/vsynth2-h261.avi
+70e9342de71456cd6fbe9a771cceefd5 *tests/data/fate/vsynth2-h261.avi
 257928 tests/data/fate/vsynth2-h261.avi
 1a9bb0d52bd24cb62162c5e3c2aed317 *tests/data/fate/vsynth2-h261.out.rawvideo
 stddev:    7.21 PSNR: 30.97 MAXDIFF:   96 bytes:  7603200/  7603200

--- a/tests/ref/vsynth/vsynth2-mpeg4
+++ b/tests/ref/vsynth/vsynth2-mpeg4
@@ -1,4 +1,4 @@
-f60260ca447624a19ad8307abad7a431 *tests/data/fate/vsynth2-mpeg4.mp4
-159432 tests/data/fate/vsynth2-mpeg4.mp4
+5476cf4dc144eac67b12737fd8966641 *tests/data/fate/vsynth2-mpeg4.mp4
+159493 tests/data/fate/vsynth2-mpeg4.mp4
 871fda3853f4766669ad875923920bd5 *tests/data/fate/vsynth2-mpeg4.out.rawvideo
 stddev:    6.02 PSNR: 32.53 MAXDIFF:   89 bytes:  7603200/  7603200


### PR DESCRIPTION
Hi,

Here is a patchset containing backports of everything I could from libav-stable since 11.4.

Some patches did not apply cleanly and so were left out. Would you like me to supply a list of them?